### PR TITLE
Removed TimeZoneConverter

### DIFF
--- a/Lullaby/Controllers/Ical/Events/GroupEventController.cs
+++ b/Lullaby/Controllers/Ical/Events/GroupEventController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Mvc;
 using Requests.Ical.Events;
 using Services.Events;
 using Swashbuckle.AspNetCore.Annotations;
-using TimeZoneConverter;
 
 [Controller]
 [Produces("text/calendar")]
@@ -66,7 +65,7 @@ public class GroupEventController : ControllerBase
             )
         };
 
-        var asiaTokyoTimezone = TZConvert.GetTimeZoneInfo("Asia/Tokyo");
+        var asiaTokyoTimezone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
         var calendarEvents = events
             .Select(e => new CalendarEvent
             {

--- a/Lullaby/Crawler/Scraper/TimeTree/TimeTreeApiClient.cs
+++ b/Lullaby/Crawler/Scraper/TimeTree/TimeTreeApiClient.cs
@@ -3,7 +3,6 @@ namespace Lullaby.Crawler.Scraper.TimeTree;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Flurl;
-using TimeZoneConverter;
 
 public class TimeTreeApiClient : ITimeTreeApiClient
 {
@@ -94,7 +93,7 @@ public class TimeTreeApiClient : ITimeTreeApiClient
 
     private static DateTimeOffset ForciblySetTimeZoneToDateTimeOffset(DateTimeOffset dateTimeOffset, string timezone)
     {
-        var timezoneInfo = TZConvert.GetTimeZoneInfo(timezone);
+        var timezoneInfo = TimeZoneInfo.FindSystemTimeZoneById(timezone);
         return new DateTimeOffset(dateTimeOffset.DateTime, timezoneInfo.BaseUtcOffset);
     }
 

--- a/Lullaby/Lullaby.csproj
+++ b/Lullaby/Lullaby.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Sentry.AspNetCore" Version="3.39.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
see: https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/#time-zone-conversion-apis