### PR TITLE
PRSMINおよびYOLOZの深夜イベントの取り扱いを修正する

### DIFF
--- a/Lullaby.Common/Crawler/Scraper/Ryzm/RyzmScheduleObject.cs
+++ b/Lullaby.Common/Crawler/Scraper/Ryzm/RyzmScheduleObject.cs
@@ -76,13 +76,7 @@ public class RyzmScheduleObject
 
         [JsonPropertyName("body")] public object Body { get; init; } = null!;
 
-        [JsonPropertyName("publishes_at")] public DateTimeOffset PublishesAt { get; init; }
-
         [JsonPropertyName("archived")] public int Archived { get; init; }
-
-        [JsonPropertyName("created_at")] public DateTimeOffset CreatedAt { get; init; }
-
-        [JsonPropertyName("updated_at")] public DateTimeOffset UpdatedAt { get; init; }
     }
 
     public class ReservationSetting


### PR DESCRIPTION
「# BFF OSAKA VOL.2 」（日付が回ったあとの深夜イベント）の開催により、パーサーが壊れてしまっていたので修正する。