### PR TITLE
feat(Fokalite): temporarily disable FokaliteCrawlerJob due to group calendar migration to GCal

### DIFF
--- a/Lullaby.Jobs/Job/ConfigureLullabyScheduledJobs.cs
+++ b/Lullaby.Jobs/Job/ConfigureLullabyScheduledJobs.cs
@@ -110,6 +110,7 @@ public static class ConfigureLullabyScheduledJobs
         // FOKALITE - fokalite
         recurringJobManager.AddOrUpdate<FokaliteCrawlerJob>(
             FokaliteCrawlerJob.JobKey,
+            // disable for now because group calendar has moved to GCal
             x => x.Execute(default),
             Cron.Hourly()
         );

--- a/Lullaby.Jobs/Job/FokaliteCrawlerJob.cs
+++ b/Lullaby.Jobs/Job/FokaliteCrawlerJob.cs
@@ -13,4 +13,9 @@ public class FokaliteCrawlerJob(
     public const string JobKey = "FokaliteCrawlerJob";
 
     protected override IGroup TargetGroup => fokalite;
+
+    /// <summary>
+    /// disable for now because group calendar has moved to GCal
+    /// </summary>
+    public override Task Execute(CancellationToken cancellationToken = default) => Task.CompletedTask;
 }


### PR DESCRIPTION
This pull request includes changes to temporarily disable the `FokaliteCrawlerJob` because the group calendar has moved to Google Calendar (GCal). The changes ensure that the job does not execute any operations while it is disabled.

### Disabling `FokaliteCrawlerJob`:

* [`Lullaby.Jobs/Job/ConfigureLullabyScheduledJobs.cs`](diffhunk://#diff-dc1b0aa0da55a8da1c7a83b99fc92a6d08bd2b7490c20db64943da277ff5731bR113): Added a comment explaining that the `FokaliteCrawlerJob` is disabled due to the group calendar's migration to GCal.
* [`Lullaby.Jobs/Job/FokaliteCrawlerJob.cs`](diffhunk://#diff-4b1047537790b7e8a6a6cebd3951e0e837b67359ebde6401b4c4642a793cac98R16-R20): Overrode the `Execute` method in `FokaliteCrawlerJob` to return a completed task, effectively disabling the job's functionality. Also added a comment to document the reason for disabling the job.